### PR TITLE
mysqlからh2databaseに移行

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testImplementation 'com.github.database-rider:rider-spring:1.38.1'
 	testImplementation 'com.github.database-rider:rider-core:1.38.1'
+	implementation group: 'com.h2database', name: 'h2', version: '2.3.232'
+	
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/demo/model/User.java
+++ b/src/main/java/com/example/demo/model/User.java
@@ -4,7 +4,7 @@ import lombok.Data;
 
 @Data
 @Entity
-@Table(name = "user")
+@Table(name = "users")
 public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,8 +2,10 @@ spring:
     application:
         name: demo
     datasource:
-        url: jdbc:mysql://localhost:3306/test
-        username: root
-        password: Yokohama14
-        driver-class-name: com.mysql.cj.jdbc.Driver
-
+        url: jdbc:h2:mem:testdb
+        driverClassName: org.h2.Driver
+        username: sa
+        password: password
+    jpa:
+        database-platform: org.hibernate.dialect.H2Dialect
+        defer-datasource-initialization: true

--- a/src/main/sql/create_favorites_table.sql
+++ b/src/main/sql/create_favorites_table.sql
@@ -1,5 +1,5 @@
 CREATE TABLE
-    `like` (
+    `favorites` (
         `user_id` VARCHAR(15) NOT NULL,
         `post_id` int NOT NULL,
         `created_at` DATETIME,

--- a/src/main/sql/create_posts_table.sql
+++ b/src/main/sql/create_posts_table.sql
@@ -1,5 +1,5 @@
 CREATE TABLE
-    `post` (
+    `posts` (
         `id` int NOT NULL AUTO_INCREMENT PRIMARY KEY,
         `user_id` VARCHAR(15) NOT NULL,
         `content` VARCHAR(140) NOT NULL,

--- a/src/main/sql/create_users_table.sql
+++ b/src/main/sql/create_users_table.sql
@@ -1,6 +1,6 @@
 CREATE TABLE
-    `user` (
-        `uuid` CHAR(36) NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    `users` (
+        `uuid` CHAR(36) NOT NULL PRIMARY KEY,
         `user_id` VARCHAR(15) NOT NULL UNIQUE,
         `name` VARCHAR(30) NOT NULL,
         `mail` VARCHAR(50) NOT NULL,


### PR DESCRIPTION
テーブル名がuserだとローカル起動時に文法エラーが発生するため、すべてのテーブル名を複数形に変更しました。
ローカル起動時のDB初期化は次のPRで対応予定です