### PR TITLE
投稿削除の際にお気に入りテーブルからも削除するように修正

### DIFF
--- a/src/main/java/com/example/demo/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/demo/GlobalExceptionHandler.java
@@ -66,7 +66,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(PostNotDeletedException.class)
-    public ResponseEntity<ErrorResponseBody> handlPostNotDeletedException(PostNotDeletedException e) {
+    public ResponseEntity<ErrorResponseBody> handlePostNotDeletedException(PostNotDeletedException e) {
         ErrorResponseBody errorResponseBody = new ErrorResponseBody();
         errorResponseBody.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
         errorResponseBody.setErrorMessage(e.getMessage());

--- a/src/main/java/com/example/demo/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/demo/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import com.example.demo.exception.FavoriteNotCreatedException;
 import com.example.demo.exception.FavoriteNotGetException;
 import com.example.demo.exception.NotLoginUserException;
 import com.example.demo.exception.PostNotCreatedException;
+import com.example.demo.exception.PostNotDeletedException;
 import com.example.demo.exception.PostNotGetException;
 import com.example.demo.exception.UserNotCreatedException;
 import com.example.demo.model.ErrorResponseBody;
@@ -42,12 +43,12 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(FavoriteNotGetException.class)
     public ResponseEntity<ErrorResponseBody> handleFavoriteNotGetException(FavoriteNotGetException e) {
-          ErrorResponseBody errorResponseBody = new ErrorResponseBody();
+        ErrorResponseBody errorResponseBody = new ErrorResponseBody();
         errorResponseBody.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
         errorResponseBody.setErrorMessage(e.getMessage());
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponseBody);
     }
-  
+
     @ExceptionHandler(NotLoginUserException.class)
     public ResponseEntity<ErrorResponseBody> handleNotLoginUserException(NotLoginUserException e) {
         ErrorResponseBody errorResponseBody = new ErrorResponseBody();
@@ -58,6 +59,14 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(UserNotCreatedException.class)
     public ResponseEntity<ErrorResponseBody> handleUserNotCreatedException(UserNotCreatedException e) {
+        ErrorResponseBody errorResponseBody = new ErrorResponseBody();
+        errorResponseBody.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
+        errorResponseBody.setErrorMessage(e.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponseBody);
+    }
+
+        @ExceptionHandler(PostNotDeletedException.class)
+    public ResponseEntity<ErrorResponseBody> handlPostNotDeletedException(PostNotDeletedException e) {
         ErrorResponseBody errorResponseBody = new ErrorResponseBody();
         errorResponseBody.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
         errorResponseBody.setErrorMessage(e.getMessage());

--- a/src/main/java/com/example/demo/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/demo/GlobalExceptionHandler.java
@@ -65,7 +65,7 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponseBody);
     }
 
-        @ExceptionHandler(PostNotDeletedException.class)
+    @ExceptionHandler(PostNotDeletedException.class)
     public ResponseEntity<ErrorResponseBody> handlPostNotDeletedException(PostNotDeletedException e) {
         ErrorResponseBody errorResponseBody = new ErrorResponseBody();
         errorResponseBody.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());

--- a/src/main/java/com/example/demo/exception/PostNotDeletedException.java
+++ b/src/main/java/com/example/demo/exception/PostNotDeletedException.java
@@ -1,0 +1,10 @@
+package com.example.demo.exception;
+
+/**
+ * 投稿削除の際、DBアクセスエラー発生時に使用するカスタムクラス
+ */
+public class PostNotDeletedException extends RuntimeException {
+    public PostNotDeletedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/demo/repository/FavoriteRepository.java
+++ b/src/main/java/com/example/demo/repository/FavoriteRepository.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Repository;
 
 import com.example.demo.model.Favorite;
 import com.example.demo.model.FavoritePK;
+import com.example.demo.model.Post;
 import com.example.demo.model.User;
 
 import java.util.List;
@@ -12,4 +13,5 @@ import java.util.List;
 @Repository
 public interface FavoriteRepository extends CrudRepository<Favorite, FavoritePK> {
     List<Favorite> findByUser(User user);
+    void deleteByPost(Post post);
 }

--- a/src/main/java/com/example/demo/service/PostServiceImpl.java
+++ b/src/main/java/com/example/demo/service/PostServiceImpl.java
@@ -45,9 +45,11 @@ public class PostServiceImpl implements PostService {
     @Override
     public void deletePost(Long id) {
         try {
-            Post deletePost = new Post();
-            deletePost.setId(id);
+            Post deletePost = postRepository.findById(id)
+                    .orElseThrow(() -> new PostNotDeletedException("指定された投稿が見つかりませんでした。"));
+
             favoriteRepository.deleteByPost(deletePost);
+
             postRepository.deleteById(id);
         } catch (DataAccessException e) {
             throw new PostNotDeletedException("投稿を削除できませんでした。");

--- a/src/test/java/com/example/demo/PostServiceTest.java
+++ b/src/test/java/com/example/demo/PostServiceTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDateTime;
@@ -19,6 +20,7 @@ import org.springframework.dao.DataAccessException;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import com.example.demo.exception.PostNotCreatedException;
+import com.example.demo.exception.PostNotDeletedException;
 import com.example.demo.exception.PostNotGetException;
 import com.example.demo.model.Post;
 import com.example.demo.model.User;
@@ -55,13 +57,21 @@ public class PostServiceTest {
         DataAccessException dataAccessException = new DataAccessException("error") {
         };
         when(postRepository.save(any())).thenThrow(dataAccessException);
-        PostNotCreatedException exception = assertThrows(PostNotCreatedException.class, () -> postService.createPost(createPostRequest));
+        PostNotCreatedException exception = assertThrows(PostNotCreatedException.class,
+                () -> postService.createPost(createPostRequest));
         assertEquals(exception.getMessage(), "投稿を作成できませんでした。");
     }
 
     @Test
     void testDeletePost() {
-        assertDoesNotThrow(() -> postService.deletePost((long)1));
+        assertDoesNotThrow(() -> postService.deletePost((long) 1));
+    }
+
+    @Test
+    void testDeletePostThrowsException() {
+        doThrow(new DataAccessException("error") {}).when(postRepository).deleteById((long)2);
+        PostNotDeletedException exception = assertThrows(PostNotDeletedException.class, () -> postService.deletePost((long)2));
+        assertEquals(exception.getMessage(), "投稿を削除できませんでした。");
     }
 
     @Test


### PR DESCRIPTION
### 詳細説明
投稿を削除する前に、お気に入りテーブルから投稿IDに紐づくレコードを削除するように修正しました。