### PR TITLE
投稿作成機能の新規作成

### DIFF
--- a/frontend/app/components/CreatePost.vue
+++ b/frontend/app/components/CreatePost.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+import { usePost } from '~/composables/usePost';
+const { createPost } = usePost();
+const userStore = useUserStore();
+
+interface Emits {
+    (event: "refreshPostData"): void,
+    (event: "showErrorToast", title: string, description: string): void,
+}
+
+const emit = defineEmits<Emits>();
+
+const state = reactive({
+    content: '',
+})
+async function submit() {
+    try {
+        await createPost(userStore.getLoginUserId, state.content, null);
+        state.content = '';
+        emit("refreshPostData");
+    } catch (error: any) {
+        //400,500番台の場合はエラートーストを表示
+        if (error.message) {
+            emit("showErrorToast", "error", "投稿を作成できませんでした。");
+        } else {
+            //ネットワークエラーのerror.vueを表示
+            throw createError({ statusCode: 500, statusMessage: 'ネットワークエラーが発生しました。', fatal: true })
+        }
+    }
+}
+
+const goToProfile = async () => {
+    await navigateTo('/UserPage')
+}
+
+const disableFlag = computed(() => !state.content);
+
+</script>
+
+<template>
+    <UContainer class="flex flex-col border-1 rounded-none mt-0.5 w-full h-32">
+        <div class="flex mt-2">
+            <div class="cursor-pointer" @click="goToProfile">
+                <UAvatar class="mr-2 " src="/img/exampleImage.png" size="sm" />
+            </div>
+
+            <textarea v-model=state.content minlength="1" maxlength="140"
+                class="resize-none h-20 w-full focus:outline-none" placeholder="いまなにしてる？"></textarea>
+        </div>
+        <div class="mt-1 flex flex-row-reverse">
+            <UButton @click="submit" :disabled=disableFlag>ポストする</UButton>
+        </div>
+    </UContainer>
+</template>

--- a/frontend/app/components/Post.vue
+++ b/frontend/app/components/Post.vue
@@ -6,6 +6,11 @@ interface Props {
 
 const props = defineProps<Props>();
 
+const createdDate = computed(() => {
+    const date = new Date(props.post.createdAt);
+    return date.toLocaleString();
+})
+
 </script>
 
 <template>
@@ -15,6 +20,7 @@ const props = defineProps<Props>();
                 <UAvatar src="/img/exampleImage.png" size="sm" />
                 <div class="ml-1">{{ post.userName }}</div>
                 <div class="ml-1 text-gray-400">@{{ post.userId }}</div>
+                <div class="ml-5">{{ createdDate }}</div>
             </div>
         </template>
 

--- a/frontend/app/composables/useLogin.ts
+++ b/frontend/app/composables/useLogin.ts
@@ -13,7 +13,7 @@ export interface User {
 export interface LoginResponse {
     success: boolean,
     message: string,
-    User: User,
+    user: User,
 }
 
 export const useLogin = () => {

--- a/frontend/app/composables/usePost.ts
+++ b/frontend/app/composables/usePost.ts
@@ -24,5 +24,22 @@ export const usePost = () => {
             throw new Error(error.data?.errorMessage);
         }
     }
-    return { getPost };
+
+    const createPost = async (userId: string, content: string, replyTo: number | null): Promise<void> => {
+        try {
+            await $fetch('/post/create', {
+                baseURL: config.public.apiBase,
+                method: 'POST',
+                body: {
+                    userId: userId,
+                    content: content,
+                    replyTo: replyTo,
+                }
+            })
+        } catch (error: any) {
+            console.log(error);
+            throw new Error(error.data?.errorMessage);
+        }
+    }
+    return { getPost, createPost };
 }

--- a/frontend/app/pages/TimeLine.vue
+++ b/frontend/app/pages/TimeLine.vue
@@ -1,11 +1,16 @@
 <script setup lang="ts">
+import { error } from 'console';
+
 const { getPost } = usePost()
 const postStore = usePostStore();
+const toast = useToast()
 
 const state = reactive({
     showAlertFlag: false,
     alertMessage: "",
 })
+
+
 
 onMounted(async () => {
     try {
@@ -14,20 +19,45 @@ onMounted(async () => {
     } catch (error: any) {
         //400,500番台の場合はエラーアラートを表示
         if (error.message) {
-            state.showAlertFlag = true;
-            state.alertMessage = error.message;
+
         } else {
-            //ネットワークエラーのerro.vueを表示
+            //ネットワークエラーのerror.vueを表示
             throw createError({ statusCode: 500, statusMessage: 'ネットワークエラーが発生しました。', fatal: true })
         }
     }
 })
+
+const showToast = (title: string, description: string) => {
+    toast.add({
+        title: title,
+        description: description,
+        color: title === "error" ? "error" : "success"
+    })
+}
+
+const refreshPostData = async () => {
+    try {
+        const posts: Post[] = await getPost();
+        postStore.posts = [...posts];
+        showToast('success', '投稿が作成されました。');
+    } catch (error: any) {
+        //400,500番台の場合はエラーアラートを表示
+        if (error.message) {
+            state.showAlertFlag = true;
+            state.alertMessage = error.message;
+        } else {
+            //ネットワークエラーのerror.vueを表示
+            throw createError({ statusCode: 500, statusMessage: 'ネットワークエラーが発生しました。', fatal: true })
+        }
+    }
+}
 </script>
 
 <template>
     <UContainer class="h-screen flex-col flex justify-center items-center">
-        <UAlert  v-if="state.showAlertFlag" color="error" class="w-1/2" :title=state.alertMessage />
+        <UAlert v-if="state.showAlertFlag" color="error" class="w-1/2" :title=state.alertMessage />
         <div class="h-full w-1/2 flex-col items-center justify-items-center hidden-scrollbar bg-white">
+            <CreatePost @refreshPostData="refreshPostData" @showErrorToast="showToast"></CreatePost>
             <Post v-for="post in postStore.getPosts" :post="post"></Post>
         </div>
     </UContainer>

--- a/frontend/app/pages/UserPage.vue
+++ b/frontend/app/pages/UserPage.vue
@@ -1,0 +1,8 @@
+<script setup lang="ts">
+</script>
+
+<template>
+    <UContainer>
+        <div>ユーザーページ</div>
+    </UContainer>
+</template>

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -4,6 +4,7 @@ import * as v from 'valibot'
 import type { LoginResponse } from '~/composables/useLogin'
 
 const { login } = useLogin();
+const userStore = useUserStore();
 
 const state = reactive({
     email: '',
@@ -19,12 +20,13 @@ const schema = v.object({
     password: v.pipe(v.string(), v.nonEmpty('パスワードを入力してください'))
 })
 
-async function submit() {
+const submit = async () => {
     try {
         state.showLoadingFlag = true;
         const response: LoginResponse = await login(state.email, state.password);
         state.showLoadingFlag = false;
         if (response.success) {
+            userStore.setLoginUserInfo(response.user);
             state.showAlertFlag = false;
             await navigateTo('/timeline');
         } else {

--- a/frontend/stores/user.ts
+++ b/frontend/stores/user.ts
@@ -1,0 +1,37 @@
+import { defineStore } from 'pinia'
+
+export const useUserStore = defineStore('user', {
+    state: () => {
+        return {
+            LoginUser: {
+                uuid: '',
+                userId: '',
+                name: '',
+                mail: '',
+                profile: '',
+                birthDate: '',
+                iconImage: '',
+                password: '',
+            } as User
+        }
+    },
+
+    actions: {
+        setLoginUserInfo (user: User) {
+            this.LoginUser.uuid = user.uuid;
+            this.LoginUser.userId = user.userId;
+            this.LoginUser.name = user.name;
+            this.LoginUser.mail = user.mail;
+            this.LoginUser.profile = user.profile;
+            this.LoginUser.birthDate = user.birthDate;
+            this.LoginUser.iconImage = user.iconImage;
+            this.LoginUser.password = user.password;
+        }
+    },
+
+    getters: {
+        getLoginUserId:(state) => {
+            return state.LoginUser.uuid;
+        }
+    },
+})

--- a/src/main/java/com/example/demo/repository/PostRepository.java
+++ b/src/main/java/com/example/demo/repository/PostRepository.java
@@ -1,9 +1,10 @@
 package com.example.demo.repository;
 
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 import com.example.demo.model.Post;
 
 @Repository
-public interface PostRepository extends CrudRepository<Post, Long> {
+public interface PostRepository extends JpaRepository<Post, Long> {
 }

--- a/src/main/java/com/example/demo/service/PostServiceImpl.java
+++ b/src/main/java/com/example/demo/service/PostServiceImpl.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataAccessException;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -59,7 +60,7 @@ public class PostServiceImpl implements PostService {
     @Override
     public List<GetAllPostResponse> findAllPost() {
         try {
-            Iterable<Post> posts = postRepository.findAll();
+            Iterable<Post> posts = postRepository.findAll(Sort.by(Sort.Direction.DESC, "createdAt"));
             List<GetAllPostResponse> response = new ArrayList<>();
             posts.forEach(post -> {
                 GetAllPostResponse res = new GetAllPostResponse();

--- a/src/test/java/com/example/demo/PostRepositoryTest.java
+++ b/src/test/java/com/example/demo/PostRepositoryTest.java
@@ -36,7 +36,7 @@ class PostRepositoryTest {
         // 期待値の作成
         Post expectPost = new Post();
         expectPost.setContent("これはPost作成のテストです");
-        expectPost.setId((long) 7);
+        expectPost.setId((long) 14);
         expectPost.setUserId(user);
         LocalDateTime now = LocalDateTime.now();
         expectPost.setCreatedAt(now);
@@ -46,7 +46,7 @@ class PostRepositoryTest {
         createPostInfo.setUserId(user);
         postRepository.save(createPostInfo);
 
-        Optional<Post> post = postRepository.findById((long) 7);
+        Optional<Post> post = postRepository.findById((long) 14);
         Post resultPost = post.get();
         assertEquals(expectPost.getId(), resultPost.getId());
         assertEquals(expectPost.getUserId().getUuid(), resultPost.getUserId().getUuid());
@@ -62,18 +62,18 @@ class PostRepositoryTest {
         Iterable<Post> response = postRepository.findAll();
         List<Post> actual = new ArrayList<>();
         response.forEach(actual::add);
-        assertEquals(6, actual.size());
+        assertEquals(13, actual.size());
         assertEquals(1, actual.get(0).getId());
-        assertEquals("123e4567-e89b-12d3-a456-426614174000", actual.get(0).getUserId().getUuid());
+        assertEquals("323e4567-e89b-12d3-a456-426614174002", actual.get(0).getUserId().getUuid());
         assertEquals("初めての投稿です。よろしくお願いします。", actual.get(0).getContent());
         assertEquals(null, actual.get(0).getReplyTo());
         assertEquals(2, actual.get(1).getId());
         assertEquals("223e4567-e89b-12d3-a456-426614174001", actual.get(1).getUserId().getUuid());
-        assertEquals("初めての投稿です。よろしくお願いします。", actual.get(1).getContent());
+        assertEquals("2回目の投稿です。", actual.get(1).getContent());
         assertEquals(null, actual.get(1).getReplyTo());
         assertEquals(3, actual.get(2).getId());
         assertEquals("123e4567-e89b-12d3-a456-426614174000", actual.get(2).getUserId().getUuid());
-        assertEquals("2回目の投稿です。", actual.get(2).getContent());
+        assertEquals("3回目の投稿です。", actual.get(2).getContent());
         assertEquals(null, actual.get(2).getReplyTo());
     }
 

--- a/src/test/java/com/example/demo/PostServiceTest.java
+++ b/src/test/java/com/example/demo/PostServiceTest.java
@@ -18,6 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.dao.DataAccessException;
+import org.springframework.data.domain.Sort;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import com.example.demo.exception.PostNotCreatedException;
@@ -158,9 +159,9 @@ public class PostServiceTest {
         post2.setReplyTo(null);
         post2.setCreatedAt(localDateTime);
 
-        Iterable<Post> mockResponse = new ArrayList<>(List.of(post1, post2));
+        List<Post> mockResponse = new ArrayList<>(List.of(post1, post2));
 
-        when(postRepository.findAll()).thenReturn(mockResponse);
+        when(postRepository.findAll(Sort.by(Sort.Direction.ASC, "createdAt"))).thenReturn(mockResponse);
 
         List<GetAllPostResponse> acutualResponse = postService.findAllPost();
 


### PR DESCRIPTION
### 詳細説明
-ユーザーが新規に投稿を作成する機能を追加しました
-投稿に成功した場合、投稿情報を再取得して表示します
-投稿が成功/失敗した場合エラートーストが表示され、ネットワークエラーの場合はエラー画面に遷移します。
-0文字で投稿できないように、文字を入力していない場合はボタンが非活性になる制御をいれました。

投稿作成前
<img width="1028" height="925" alt="image" src="https://github.com/user-attachments/assets/ba7b1a6c-d6cd-415a-821d-6b6b69fd69c4" />

投稿作成後
<img width="1025" height="908" alt="image" src="https://github.com/user-attachments/assets/e5263937-091c-4c16-a2c6-1db3b47621a9" />
